### PR TITLE
ci: add "id-token" permission

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,7 @@ jobs:
       packages: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Closes https://github.com/ms-dosx86/ng-error-handlers/issues/4