### PR TITLE
ci: use classic github token

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,5 +22,5 @@ jobs:
       - run: npm run build
       - run: cd projects/ng-error-handlers && npx semantic-release
         env:
-          GH_TOKEN: ${{secrets.GH_TOKEN}}
-          NPM_TOKEN: ${{secrets.GH_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Closes https://github.com/ms-dosx86/ng-error-handlers/issues/6